### PR TITLE
issue 4942: rewrite: add snapshot size to old snapshots

### DIFF
--- a/changelog/unreleased/issue-4942
+++ b/changelog/unreleased/issue-4942
@@ -1,0 +1,10 @@
+Enhancement: create snapshot summary statistics for snapshots which don't have them
+
+When restic rewrite is used with the -s (snapshot-summary) option,
+a new snapshot is created containing statistics summary data. Only two fields
+will be non-zero: TotalFilesProcessed and TotalBytesProcessed
+
+When restic rewrite is used to remove certain parts of the snapshot, the new feature
+will alse be activated.
+
+https://github.com/restic/restic/issues/4942

--- a/cmd/restic/wpl_history.go
+++ b/cmd/restic/wpl_history.go
@@ -1,0 +1,114 @@
+package main
+
+/*
+Execute snapshot-summary function: build the Snapshot.Summary section if
+it does not exist.
+
+In DryRun mode the calculations will be done, but no changes will be made.
+
+Specify extra verbosity to see the numbers on stdout.
+
+If you want to compare numbers with a snapshot which has already statistics
+data attached, run:
+restic -r <repo> rewrite -svn <snap_id>
+*/
+
+import (
+	// system
+	"context"
+	"time"
+
+	// restic
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/walker"
+)
+
+// run rewrite --snapshot-summary subcommand
+func rewriteSnapshotSummary(ctx context.Context, repo *repository.Repository,
+	gopts GlobalOptions, snapshotLister restic.Lister, SnapshotFilter *restic.SnapshotFilter,
+	args []string, opts RewriteOptions) error {
+
+	for currentBackup := range FindFilteredSnapshots(ctx, snapshotLister, repo, SnapshotFilter, args) {
+		if currentBackup.Summary != nil && currentBackup.Summary.TotalBytesProcessed > 0 {
+			Verboseff("snap_id %s already has a summary section\n", currentBackup.ID().Str())
+			if !opts.DryRun {
+				continue
+			}
+		}
+
+		ss := &restic.SnapshotSummary{}
+		// currentBackup gets a Summary section attached
+		err := BuildSnapSummary(ctx, repo, currentBackup, currentBackup.Tree, ss)
+		if err != nil {
+			return err
+		}
+
+		if !opts.DryRun {
+			currentBackup.Original = currentBackup.ID()
+			new_id, err := restic.SaveSnapshot(ctx, repo, currentBackup)
+			if err != nil {
+				Printf("Could not create new snap record - reason %v\n", err)
+				return err
+			}
+			Verbosef("saved new snapshot %v\n", new_id.Str())
+
+			// remove current snapshot record?
+			if opts.Forget {
+				if err = repo.RemoveUnpacked(ctx, restic.SnapshotFile, *currentBackup.ID()); err != nil {
+					Printf("RemoveUnpacked could not remove %s - reason %v\n", currentBackup.ID().Str(), err)
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// walk current snapshot, expect empty or partially filled restic.SnapshotSummary entry
+func BuildSnapSummary(ctx context.Context, repo *repository.Repository,
+	currentBackup *restic.Snapshot, currentTree *restic.ID, ss *restic.SnapshotSummary) error {
+
+	totalFilesProcessed := uint(0)
+	totalBytesProcessed := uint64(0)
+	Verboseff("loading current  backup %s from %s for %s:%s\n",
+		currentBackup.ID().Str(),
+		currentBackup.Time.Format(time.DateTime),
+		currentBackup.Hostname, currentBackup.Paths[0])
+
+	// walk tree for current snapshot
+	err := walker.Walk(ctx, repo, *currentTree,
+		walker.WalkVisitor{ProcessNode: func(parentTreeID restic.ID, nodepath string, node *restic.Node, err error) error {
+			if err != nil {
+				Printf("Unable to load tree %s\n ... which belongs to snapshot %s - reason %v\n", parentTreeID, currentBackup.ID().Str(), err)
+				return walker.ErrSkipNode
+			}
+
+			if node == nil {
+				return nil
+			} else if node.Type == "file" {
+				totalFilesProcessed += 1
+				totalBytesProcessed += node.Size
+			}
+			return nil
+		}})
+
+	if err != nil {
+		Printf("walker.Walk does not want to run for snapshot %s - reason %v\n", currentBackup.ID().Str(), err)
+		return err
+	}
+
+	Verboseff("\n")
+	Verboseff("total_files_processed %d\n", totalFilesProcessed)
+	Verboseff("total_bytes_procTotalFilesProcessedessed %d\n\n", totalBytesProcessed)
+
+	// build partial snapshot statistics record
+	ss.TotalFilesProcessed = totalFilesProcessed
+	ss.TotalBytesProcessed = totalBytesProcessed
+
+	// and attach statistics to current snapshot
+	currentBackup.Summary = ss
+
+	return nil
+}


### PR DESCRIPTION
add code for above feature enhancement.
Add option --snapshot-summary [-s] to add staristics sumarry to snapsjpt record.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR  attaches snapshots statistics to existing snapshots. It also enables to create statistics for snapshots modified by the rewrite command.
A new parameter --snapshot-summary has been attached to the existing rewrite command.

Changes in rewrite:
1.) add parameter --snapshot-summary
2.) if parameter has been activated, call rewriteSnapshotSummary, which adds the the two fields totalFilesProcessed and 
totalBytesProcessed to the snapshot summary record.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/4942
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
