### PR TITLE
Cmd prune: Selection of packs to repack based on size issue #5109

### DIFF
--- a/changelog/unreleased/issue-5109
+++ b/changelog/unreleased/issue-5109
@@ -1,0 +1,10 @@
+Issue #5109 - Selection of packs to repack based on size
+
+Add option --small-pack-size so prune can repack all packfiles smaller than small-pack-size bytes.
+The new option is passed onto internal/repository/prune.go.
+A new decision has been added to "decide what to do" to
+move the intended packfiles onto the repackSmallCandidates queue.
+
+The decision what to do with the candidate in repackSmallCandidates has been modofied,
+so prune can be forced to process the intended repacking operation -by setting
+--max-unused to a low value.

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -56,6 +56,9 @@ type PruneOptions struct {
 	MaxRepackSize  string
 	MaxRepackBytes uint64
 
+	SmallPackSize  string
+	SmallPackBytes uint64
+
 	RepackCacheableOnly bool
 	RepackSmall         bool
 	RepackUncompressed  bool
@@ -78,6 +81,7 @@ func addPruneOptions(c *cobra.Command, pruneOptions *PruneOptions) {
 	f.BoolVar(&pruneOptions.RepackCacheableOnly, "repack-cacheable-only", false, "only repack packs which are cacheable")
 	f.BoolVar(&pruneOptions.RepackSmall, "repack-small", false, "repack pack files below 80% of target pack size")
 	f.BoolVar(&pruneOptions.RepackUncompressed, "repack-uncompressed", false, "repack all uncompressed data")
+	f.StringVar(&pruneOptions.SmallPackSize, "small-pack-size", "0", "pack `below-limit` packfiles smaller than (allowed suffixes: k/K, m/M, g/G, t/T)")
 }
 
 func verifyPruneOptions(opts *PruneOptions) error {
@@ -136,6 +140,13 @@ func verifyPruneOptions(opts *PruneOptions) error {
 		}
 	}
 
+	smallPackSize := strings.TrimSpace(opts.SmallPackSize)
+	size, err := ui.ParseBytes(smallPackSize)
+	if err != nil {
+		return errors.Fatalf("invalid number of bytes %q for --small-pack-size: %v", opts.SmallPackSize, err)
+	}
+	opts.SmallPackBytes = uint64(size)
+
 	return nil
 }
 
@@ -149,11 +160,7 @@ func runPrune(ctx context.Context, opts PruneOptions, gopts GlobalOptions, term 
 		return errors.Fatal("disabled compression and `--repack-uncompressed` are mutually exclusive")
 	}
 
-	if gopts.NoLock && !opts.DryRun {
-		return errors.Fatal("--no-lock is only applicable in combination with --dry-run for prune command")
-	}
-
-	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, opts.DryRun && gopts.NoLock)
+	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false)
 	if err != nil {
 		return err
 	}
@@ -191,6 +198,9 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, gopts GlobalOption
 
 		MaxUnusedBytes: opts.maxUnusedBytes,
 		MaxRepackBytes: opts.MaxRepackBytes,
+
+		SmallPackSize:  opts.SmallPackSize,
+		SmallPackBytes: opts.SmallPackBytes,
 
 		RepackCacheableOnly: opts.RepackCacheableOnly,
 		RepackSmall:         opts.RepackSmall,


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR allows repacking of the repository based on size of the packfiles.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Add option --small-pack-size so prune can repack all packfiles smaller than small-pack-size bytes.
The new option is passed onto internal/repository/prune.go.
A new decision has been added to "decide what to do" to move the intended packfiles onto the repackSmallCandidates queue.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/5109
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.