### PR TITLE
restic rewrite: issue 4278: include filters in command rewrite

### DIFF
--- a/changelog/unreleased/issue-4278
+++ b/changelog/unreleased/issue-4278
@@ -1,0 +1,31 @@
+Enhancement: include include filters in command rewrite
+
+The enhancement allows the standard include filter options
+      --iinclude pattern     same as --include pattern but ignores the casing of filenames
+      --iinclude-file file   same as --include-file but ignores casing of filenames in patterns
+  -i, --include pattern      include a pattern (can be specified multiple times)
+      --include-file file    read include patterns from a file (can be specified multiple times)
+
+In addition the option
+  -s, --snapshot-summary     create snapshot summary record if it does not exist
+
+To improve space performance of the newly created snapshots via the include filter variants,
+it is recommended to utilize the option
+	-X, --exclude-empty        exclude empty directories from being created, needs a second walk through the tree
+
+The exclusion or inclusion of filter parameters is exclusive, as in other commands
+which use both include and exclude filters.
+
+In order to make the include filter work efficiently, an additional read pass through the
+directory tree is needed to identify the subdirectories and their parents for the
+inclusion of files to work effectively. Otherwise the full directory tree needs to be included
+which as a consequence may contain quite a lot of empty subdirectories. The first read pass
+avoids this issue, but it might take a bit more time, depending on the network speed of
+the backend storage and the size of the snapshot.
+
+The --snapshot-summary parameter adds summary data to the snapshot summary section, as already
+described in the solution to issue 4942.
+
+https://github.com/restic/restic/issues/4278
+https://github.com/restic/restic/issues/4942
+https://github.com/wplapper/restic-pull/pull/7

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,10 +19,11 @@ import (
 
 var cmdRewrite = &cobra.Command{
 	Use:   "rewrite [flags] [snapshotID ...]",
-	Short: "Rewrite snapshots to exclude unwanted files",
+	Short: "Rewrite snapshots to exclude unwanted files or include wanted files",
 	Long: `
-The "rewrite" command excludes files from existing snapshots. It creates new
-snapshots containing the same data as the original ones, but without the files
+The "rewrite" command excludes files from existing snapshots.
+Alternatively you can use rewrite command to include only wanted files and directories.
+It creates new snapshots containing the same data as the original ones, but without the files
 you specify to exclude. All metadata (time, host, tags) will be preserved.
 
 The snapshots to rewrite are specified using the --host, --tag and --path options,
@@ -34,6 +37,26 @@ used, the original snapshots will instead be directly removed from the repositor
 Please note that the --forget option only removes the snapshots and not the actual
 data stored in the repository. In order to delete the no longer referenced data,
 use the "prune" command.
+
+For the include option to work more efficiently, it os advisable to use the flag
+'--exclude-empty' so only directories needed will be included from the original
+snapshot. Otherwise all directories from the original snapshot have to be included.
+This however will produce an extra Walk() through the original snapshot tree.
+
+The option 'snapshot-summary' can be used to attach summary statistics to
+an existing snapshot without them. The modified snapshot will be identical
+to the original snapshot, plus the extra 2 fields in the summary section:
+'total_files_processed' and 'total_bytes_processed'.
+
+To improve space performance of the newly created snapshots via the
+include filter variants, it is recommended to utilize the option -X, --exclude-empty.
+
+In order to make the include filter work efficiently, an additional read pass through the
+directory tree is needed to identify the subdirectories and their parents for the
+inclusion of files to work effectively. Otherwise the full directory tree needs to be included
+which may contain quite a lot of empty subdirectories. The first read pass
+avoids this issue, but it might take a bit more time, depending on the network speed of
+the backend storage and the size of the snapshot.
 
 EXIT STATUS
 ===========
@@ -83,12 +106,15 @@ func (sma snapshotMetadataArgs) convert() (*snapshotMetadata, error) {
 
 // RewriteOptions collects all options for the rewrite command.
 type RewriteOptions struct {
-	Forget bool
-	DryRun bool
+	Forget          bool
+	DryRun          bool
+	SnapshotSummary bool
+	ExcludeEmptyDir bool
 
 	Metadata snapshotMetadataArgs
 	restic.SnapshotFilter
 	filter.ExcludePatternOptions
+	filter.IncludePatternOptions
 }
 
 var rewriteOptions RewriteOptions
@@ -101,12 +127,20 @@ func init() {
 	f.BoolVarP(&rewriteOptions.DryRun, "dry-run", "n", false, "do not do anything, just print what would be done")
 	f.StringVar(&rewriteOptions.Metadata.Hostname, "new-host", "", "replace hostname")
 	f.StringVar(&rewriteOptions.Metadata.Time, "new-time", "", "replace time of the backup")
+	f.BoolVarP(&rewriteOptions.SnapshotSummary, "snapshot-summary", "s", false, "create snapshot summary record if it does not exist")
+	f.BoolVarP(&rewriteOptions.ExcludeEmptyDir, "exclude-empty", "X", false, "only for include patterns: exclude empty directories from being created, needs a second walk through the tree")
 
 	initMultiSnapshotFilter(f, &rewriteOptions.SnapshotFilter, true)
 	rewriteOptions.ExcludePatternOptions.Add(f)
+	rewriteOptions.IncludePatternOptions.Add(f)
 }
 
 type rewriteFilterFunc func(ctx context.Context, sn *restic.Snapshot) (restic.ID, error)
+
+type DirectoryNeeded struct {
+	node   *restic.Node
+	needed bool
+}
 
 func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *restic.Snapshot, opts RewriteOptions) (bool, error) {
 	if sn.Tree == nil {
@@ -118,11 +152,100 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 		return false, err
 	}
 
-	metadata, err := opts.Metadata.convert()
-
+	includeByNameFuncs, err := opts.IncludePatternOptions.CollectPatterns(Warnf)
 	if err != nil {
 		return false, err
 	}
+
+	metadata, err := opts.Metadata.convert()
+	if err != nil {
+		return false, err
+	}
+
+	// walk the complete snapshot tree and memorize the directory structure
+	directoriesNeeded := map[string]DirectoryNeeded{}
+	if opts.ExcludeEmptyDir {
+		err := walker.Walk(ctx, repo, *sn.Tree, walker.WalkVisitor{ProcessNode: func(parentTreeID restic.ID, nodepath string, node *restic.Node, err error) error {
+			if err != nil {
+				Printf("Unable to load tree %s\n ... which belongs to snapshot %s - reason %v\n", parentTreeID, sn.ID().Str(), err)
+				return walker.ErrSkipNode
+			}
+
+			if node == nil {
+				return nil
+			} else if node.Type == restic.NodeTypeDir {
+				directoriesNeeded[nodepath] = DirectoryNeeded{ // default: not needed
+					node:   node,
+					needed: false,
+				}
+				// filter directories
+				for _, include := range includeByNameFuncs {
+					matched, childMayMatch := include(nodepath)
+					if matched && childMayMatch {
+						parentData := directoriesNeeded[nodepath]
+						if !parentData.needed { // flip 'needed' bit
+							directoriesNeeded[nodepath] = DirectoryNeeded{
+								node:   parentData.node,
+								needed: true,
+							}
+						}
+					}
+				}
+			} else { // include filter processsing - filter file file names
+				for _, include := range includeByNameFuncs {
+					if node.Type == restic.NodeTypeFile {
+						matched, childMayMatch := include(nodepath)
+						if matched && childMayMatch {
+							dirpath := filepath.Dir(nodepath) // parent path
+							parentData := directoriesNeeded[dirpath]
+							if !parentData.needed { // flip 'needed' bit
+								directoriesNeeded[dirpath] = DirectoryNeeded{
+									node:   parentData.node,
+									needed: true,
+								}
+							}
+						}
+					}
+				}
+			}
+			return nil
+		}}) // end walker.Walk
+
+		if err != nil {
+			Printf("walker.Walk does not want to run for snapshot %s - reason %v\n", sn.ID().Str(), err)
+			return false, err
+		}
+
+		// go over all directory structure an find all parent nodes needed
+		for {
+			more := false
+			for dirpath, dirData := range directoriesNeeded {
+				if !dirData.needed {
+					continue
+				}
+
+				parentPath := filepath.Dir(dirpath)
+				if parentPath == "/" {
+					continue
+				}
+
+				value := directoriesNeeded[parentPath]
+				if value.needed {
+					continue
+				}
+
+				directoriesNeeded[parentPath] = DirectoryNeeded{
+					node:   value.node,
+					needed: true,
+				}
+				more = true
+			} // all directories in snapshot
+
+			if !more {
+				break
+			}
+		} // for ever
+	} // opts.ExcludeEmptyDir
 
 	var filter rewriteFilterFunc
 
@@ -140,7 +263,52 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 			if selectByName(path) {
 				return node
 			}
-			Verbosef("excluding %s\n", path)
+			Verbosef(fmt.Sprintf("excluding %s\n", path))
+			return nil
+		}
+
+		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode)
+
+		filter = func(ctx context.Context, sn *restic.Snapshot) (restic.ID, error) {
+			id, err := rewriter.RewriteTree(ctx, repo, "/", *sn.Tree)
+			if err != nil {
+				return restic.ID{}, err
+			}
+
+			ss := querySize()
+			if sn.Summary == nil { // create summary if it wasn't there before
+				sn.Summary = &restic.SnapshotSummary{}
+			}
+			sn.Summary.TotalFilesProcessed = ss.FileCount
+			sn.Summary.TotalBytesProcessed = ss.FileSize
+
+			return id, nil
+		}
+	} else if len(includeByNameFuncs) > 0 {
+		selectByName := func(nodepath string, node *restic.Node) bool {
+			for _, include := range includeByNameFuncs {
+				if node.Type == restic.NodeTypeDir {
+					if opts.ExcludeEmptyDir {
+						return directoriesNeeded[nodepath].needed
+					} else {
+						// include directories unconditionally
+						return true
+					}
+				} else if node.Type == restic.NodeTypeFile {
+					ifun, childMayMatch := include(nodepath)
+					if node.Type == restic.NodeTypeFile && ifun && childMayMatch {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		rewriteNode := func(node *restic.Node, path string) *restic.Node {
+			if selectByName(path, node) {
+				Verboseff("including %s\n", path)
+				return node
+			}
 			return nil
 		}
 
@@ -152,13 +320,14 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 				return restic.ID{}, err
 			}
 			ss := querySize()
-			if sn.Summary != nil {
-				sn.Summary.TotalFilesProcessed = ss.FileCount
-				sn.Summary.TotalBytesProcessed = ss.FileSize
+			if sn.Summary == nil { // create summary if it wasn't there before
+				sn.Summary = &restic.SnapshotSummary{}
 			}
-			return id, err
-		}
+			sn.Summary.TotalFilesProcessed = ss.FileCount
+			sn.Summary.TotalBytesProcessed = ss.FileSize
 
+			return id, nil
+		}
 	} else {
 		filter = func(_ context.Context, sn *restic.Snapshot) (restic.ID, error) {
 			return *sn.Tree, nil
@@ -263,8 +432,12 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *r
 }
 
 func runRewrite(ctx context.Context, opts RewriteOptions, gopts GlobalOptions, args []string) error {
-	if opts.ExcludePatternOptions.Empty() && opts.Metadata.empty() {
-		return errors.Fatal("Nothing to do: no excludes provided and no new metadata provided")
+	if !opts.ExcludePatternOptions.Empty() && !opts.IncludePatternOptions.Empty() {
+		return errors.Fatal("Both exclude and include options are provided")
+	}
+
+	if !opts.SnapshotSummary && opts.ExcludePatternOptions.Empty() && opts.IncludePatternOptions.Empty() && opts.Metadata.empty() {
+		return errors.Fatal("Nothing to do: no includes/excludes provided and no new metadata provided")
 	}
 
 	var (
@@ -292,6 +465,10 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts GlobalOptions, a
 	bar := newIndexProgress(gopts.Quiet, gopts.JSON)
 	if err = repo.LoadIndex(ctx, bar); err != nil {
 		return err
+	}
+
+	if opts.SnapshotSummary {
+		return rewriteSnapshotSummary(ctx, repo, gopts, snapshotLister, &opts.SnapshotFilter, args, opts)
 	}
 
 	changedCount := 0

--- a/cmd/restic/wpl_history.go
+++ b/cmd/restic/wpl_history.go
@@ -1,0 +1,108 @@
+package main
+
+/*
+Execute snapshot-summary function: build the Snapshot.Summary section if
+it does not exist.
+
+In DryRun mode the calculations will be done, but no changes will be made.
+
+Specify extra verbosity to see the numbers on stdout.
+
+If you want to compare numbers with a snapshot which has already statistics
+data attached, run:
+restic -r <repo> rewrite -svn <snap_id>
+*/
+
+import (
+	// system
+	"context"
+	"time"
+
+	// restic
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/walker"
+)
+
+// run rewrite --snapshot-summary subcommand
+func rewriteSnapshotSummary(ctx context.Context, repo *repository.Repository,
+	gopts GlobalOptions, snapshotLister restic.Lister, SnapshotFilter *restic.SnapshotFilter,
+	args []string, opts RewriteOptions) error {
+
+	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, SnapshotFilter, args) {
+		if sn.Summary != nil {
+			Verboseff("snap_id %s already has a summary section\n", sn.ID().Str())
+			if !opts.DryRun {
+				continue
+			}
+		}
+
+		err := BuildSnapSummary(ctx, repo, sn)
+		if err != nil {
+			return err
+		}
+
+		if !opts.DryRun {
+			sn.Original = sn.ID()
+			sn.ProgramVersion = version
+			new_id, err := restic.SaveSnapshot(ctx, repo, sn)
+			if err != nil {
+				Printf("Could not create new snap record - reason %v\n", err)
+				return err
+			}
+			Verbosef("saved new snapshot %v\n", new_id.Str())
+
+			// remove current snapshot record?
+			if opts.Forget {
+				if err = repo.RemoveUnpacked(ctx, restic.SnapshotFile, *sn.ID()); err != nil {
+					Printf("RemoveUnpacked could not remove %s - reason %v\n", sn.ID().Str(), err)
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// walk current snapshot count files and their sizes
+func BuildSnapSummary(ctx context.Context, repo *repository.Repository, sn *restic.Snapshot) error {
+
+	TotalFilesProcessed := uint(0)
+	TotalBytesProcessed := uint64(0)
+	Verboseff("loading current  backup %s from %s for %s:%s\n",
+		sn.ID().Str(), sn.Time.Format(time.DateTime), sn.Hostname, sn.Paths[0])
+
+	err := walker.Walk(ctx, repo, *sn.Tree, walker.WalkVisitor{ProcessNode: func(parentTreeID restic.ID, nodepath string, node *restic.Node, err error) error {
+		if err != nil {
+			Printf("Unable to load tree %s\n ... which belongs to snapshot %s - reason %v\n", parentTreeID, sn.ID().Str(), err)
+			return walker.ErrSkipNode
+		}
+
+		if node == nil {
+			return nil
+		} else if node.Type == restic.NodeTypeFile {
+			TotalFilesProcessed += 1
+			TotalBytesProcessed += node.Size
+		}
+		return nil
+	}})
+
+	if err != nil {
+		Printf("walker.Walk fails for snapshot %s - reason %v\n", sn.ID().Str(), err)
+		return err
+	}
+
+	Verboseff("\n")
+	Verboseff("total_files_processed %d\n", TotalFilesProcessed)
+	Verboseff("total_bytes_processed %d\n\n", TotalBytesProcessed)
+
+	// build partial snapshot statistics record
+	if sn.Summary == nil {
+		sn.Summary = &restic.SnapshotSummary{}
+	}
+	sn.Summary.TotalFilesProcessed = TotalFilesProcessed
+	sn.Summary.TotalBytesProcessed = TotalBytesProcessed
+
+	return nil
+}

--- a/internal/filter/include.go
+++ b/internal/filter/include.go
@@ -25,6 +25,10 @@ func (opts *IncludePatternOptions) Add(f *pflag.FlagSet) {
 	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of `file`names in patterns")
 }
 
+func (opts *IncludePatternOptions) Empty() bool {
+	return len(opts.Includes) == 0 && len(opts.InsensitiveIncludes) == 0 && len(opts.IncludeFiles) == 0 && len(opts.InsensitiveIncludeFiles) == 0
+}
+
 func (opts IncludePatternOptions) CollectPatterns(warnf func(msg string, args ...interface{})) ([]IncludeByNameFunc, error) {
 	var fs []IncludeByNameFunc
 	if len(opts.IncludeFiles) > 0 {


### PR DESCRIPTION
This PR add the capability of using include filters for the rewrite command. Also included in this PR is issue 4942.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Allow include filter processing for command rewrite.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
The enhancement allows the standard include filter options
      --iinclude pattern     same as --include pattern but ignores the casing of filenames
      --iinclude-file file   same as --include-file but ignores casing of filenames in patterns
  -i, --include pattern      include a pattern (can be specified multiple times)
      --include-file file    read include patterns from a file (can be specified multiple times)

In addition the option
  -s, --snapshot-summary     create snapshot summary record if it does not exist

To improve space performance of the newly created snapshots via the include filter variants,
it is recommended to utilize the option
	-X, --exclude-empty        exclude empty directories from being created, needs a second walk through the tree

The exclusion or inclusion of filter parameters is exclusive, as in other commands
which use both include and exclude filters.

In order to make the include filter work efficiently, an additional read pass through the
directory tree is needed to identify the subdirectories and their parents for the
inclusion of files to work effectively. Otherwise the full directory tree needs to be included
which as a consequence may contain quite a lot of empty subdirectories. The first read pass
avoids this issue, but it might take a bit more time, depending on the network speed of
the backend storage and the size of the snapshot. **.**

The --snapshot-summary parameter adds summary data to the snapshot summary section, as already
described in the solution to issue 4942.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
https://github.com/restic/restic/issues/4278 and https://github.com/restic/restic/issues/4942

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
