### PR TITLE
Issue 4433: Sort order for output of find

### DIFF
--- a/changelog/unreleased/issue-4948
+++ b/changelog/unreleased/issue-4948
@@ -1,6 +1,5 @@
-Enhancement: Format exit errors as JSON with --json
+Enhancement: allow to define sorting order of command restic find.
+Add option --reverse
 
-Restic now prints any exit error messages as JSON when requested.
+https://github.com/restic/restic/issues/4433
 
-https://github.com/restic/restic/issues/4948
-https://github.com/restic/restic/pull/4952

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -56,6 +57,7 @@ type FindOptions struct {
 	CaseInsensitive    bool
 	ListLong           bool
 	HumanReadable      bool
+	Reverse            bool
 	restic.SnapshotFilter
 }
 
@@ -73,6 +75,7 @@ func init() {
 	f.BoolVar(&findOptions.PackID, "pack", false, "pattern is a pack-ID")
 	f.BoolVar(&findOptions.ShowPackID, "show-pack-id", false, "display the pack-ID the blobs belong to (with --blob or --tree)")
 	f.BoolVarP(&findOptions.CaseInsensitive, "ignore-case", "i", false, "ignore case for pattern")
+	f.BoolVarP(&findOptions.Reverse, "reverse", "R", false, "reverse sort order newest->oldest")
 	f.BoolVarP(&findOptions.ListLong, "long", "l", false, "use a long listing format showing size and mode")
 	f.BoolVar(&findOptions.HumanReadable, "human-readable", false, "print sizes in human readable format")
 
@@ -628,6 +631,9 @@ func runFind(ctx context.Context, opts FindOptions, gopts GlobalOptions, args []
 	sort.Slice(filteredSnapshots, func(i, j int) bool {
 		return filteredSnapshots[i].Time.Before(filteredSnapshots[j].Time)
 	})
+	if opts.Reverse {
+		slices.Reverse(filteredSnapshots)
+	}
 
 	for _, sn := range filteredSnapshots {
 		if f.blobIDs != nil || f.treeIDs != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR allows the reversing of the sort order for command restic find.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Add option --reverse. Call slices.Reverse().
Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/4433
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
